### PR TITLE
fix: 修复 10 个潜在 bug，提升代码健壮性

### DIFF
--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -305,3 +305,16 @@ export function getLocalizedDefaultPrompts(t: (key: string) => string) {
   // 返回本地化后的 prompts
   return localizedPrompts;
 }
+
+/**
+ * 生成唯一ID
+ * 统一的ID生成函数，避免各处实现不一致
+ * @param prefix ID前缀，用于区分来源
+ * @returns 唯一ID字符串
+ */
+export function generateUniqueId(prefix: string = 'pm'): string {
+  const timestamp = Date.now().toString(36);
+  const randomPart = Math.random().toString(36).substring(2, 11);
+  const extraRandom = Math.random().toString(36).substring(2, 6);
+  return `${prefix}_${timestamp}_${randomPart}${extraRandom}`;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -273,7 +273,7 @@ function registerCommands(context: vscode.ExtensionContext) {
     async (categoryItem) => {
       try {
         if (categoryItem && categoryItem.categoryData) {
-          await promptManager.addPrompt();
+          await promptManager.addPrompt(categoryItem.id);
           // addPrompt已经有事件触发机制，移除手动刷新
         }
       } catch (error) {
@@ -703,7 +703,7 @@ async function listCategories(categories: any[]) {
   const items = categories.map((category) => ({
     label: `$(symbol-folder) ${category.name}`,
     description: category.description || "",
-    detail: `创建于 ${category.createdAt.toLocaleDateString()}`,
+    detail: `创建于 ${category.createdAt?.toLocaleDateString() || "未知"}`,
     category: category,
   }));
 

--- a/src/models/PromptManager.ts
+++ b/src/models/PromptManager.ts
@@ -16,7 +16,7 @@ import { ImportExportService } from "../services/ImportExportService";
 import { CursorIntegrationService } from "../services/CursorIntegrationService";
 import { ChatIntegrationFactory } from "../services/ChatIntegrationFactory";
 import { ChatIntegrationOptions, ChatIntegrationStatus, EditorEnvironmentType } from "../types";
-import { DEFAULT_CATEGORIES, DEFAULT_PROMPTS } from "../constants/constants";
+import { DEFAULT_CATEGORIES, DEFAULT_PROMPTS, generateUniqueId } from "../constants/constants";
 import { t } from "../services/LocalizationService";
 
 /**
@@ -107,9 +107,9 @@ export class PromptManager implements IPromptManager {
   /**
    * 添加新Prompt
    */
-  async addPrompt(): Promise<void> {
+  async addPrompt(defaultCategoryId?: string): Promise<void> {
     try {
-      const newPrompt = await this.uiService.showPromptEditor(undefined, this.context || undefined);
+      const newPrompt = await this.uiService.showPromptEditor(undefined, this.context || undefined, defaultCategoryId);
 
       if (newPrompt) {
         await this.storageService.savePrompt(newPrompt);
@@ -458,15 +458,7 @@ export class PromptManager implements IPromptManager {
         return;
       }
 
-      // 将分类下的Prompt设为未分类
-      for (const prompt of categoryPrompts) {
-        await this.storageService.updatePrompt({
-          ...prompt,
-          categoryId: undefined,
-        });
-      }
-
-      // 删除分类
+      // 删除分类（StorageService.deleteCategory 会自动清除关联 Prompt 的 categoryId）
       await this.storageService.deleteCategory(categoryId);
 
       // 触发数据变更事件，确保UI刷新
@@ -721,7 +713,7 @@ export class PromptManager implements IPromptManager {
    * 生成唯一ID
    */
   private generateId(): string {
-    return "pm_" + Date.now().toString(36) + Math.random().toString(36).substr(2);
+    return generateUniqueId('pm');
   }
 
   // 实现IPromptManager接口缺失的方法

--- a/src/services/ImportExportService.ts
+++ b/src/services/ImportExportService.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import * as fs from "fs/promises";
 import * as path from "path";
 import { IImportExportService, ExportData, PromptItem, PromptCategory } from "../types";
-import { FILE_CONSTANTS, UI_CONSTANTS } from "../constants/constants";
+import { FILE_CONSTANTS, UI_CONSTANTS, generateUniqueId } from "../constants/constants";
 
 /**
  * 导入导出服务实现
@@ -344,6 +344,6 @@ export class ImportExportService implements IImportExportService {
    * 生成唯一ID
    */
   private generateId(): string {
-    return "import_" + Date.now().toString(36) + Math.random().toString(36).substr(2);
+    return generateUniqueId('imp');
   }
 }

--- a/src/services/StorageService.ts
+++ b/src/services/StorageService.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { IStorageService, PromptItem, PromptCategory, OperationResult } from "../types";
-import { STORAGE_KEYS, DEFAULT_CATEGORIES, DEFAULT_PROMPTS } from "../constants/constants";
+import { STORAGE_KEYS } from "../constants/constants";
 
 /**
  * 存储服务实现
@@ -23,37 +23,9 @@ export class StorageService implements IStorageService {
       return;
     }
 
-    try {
-      // 检查是否已有数据
-      const existingPrompts = await this.getPrompts();
-      const existingCategories = await this.getCategories();
-
-      // 如果没有数据，创建默认数据
-      if (existingPrompts.length === 0) {
-        console.log("首次使用，创建默认Prompt数据");
-        for (const prompt of DEFAULT_PROMPTS) {
-          // 类型转换以解决readonly兼容性问题
-          const promptItem: PromptItem = {
-            ...prompt,
-            tags: prompt.tags ? [...prompt.tags] : undefined,
-          };
-          await this.savePrompt(promptItem);
-        }
-      }
-
-      if (existingCategories.length === 0) {
-        console.log("首次使用，创建默认分类数据");
-        for (const category of Object.values(DEFAULT_CATEGORIES)) {
-          await this.saveCategory(category);
-        }
-      }
-
-      this.initialized = true;
-      console.log("StorageService初始化完成");
-    } catch (error) {
-      console.error("StorageService初始化失败:", error);
-      throw error;
-    }
+    // 默认数据创建由 PromptManager.ensureDefaultData() 统一处理
+    this.initialized = true;
+    console.log("StorageService初始化完成");
   }
 
   /**
@@ -371,7 +343,10 @@ export class StorageService implements IStorageService {
       const topCategories = Array.from(categoryCount.entries())
         .sort((a, b) => b[1] - a[1])
         .slice(0, 5)
-        .map(([categoryId]) => categoryId);
+        .map(([categoryId]) => {
+          const category = categories.find(c => c.id === categoryId);
+          return category ? category.name : categoryId;
+        });
 
       return {
         totalPrompts: prompts.length,

--- a/src/services/UIService.ts
+++ b/src/services/UIService.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { IUIService, PromptItem, PromptCategory, QuickPickPromptItem } from "../types";
-import { UI_CONSTANTS, FILE_CONSTANTS, PERFORMANCE_CONSTANTS, getLocalizedFileFilter } from "../constants/constants";
+import { UI_CONSTANTS, FILE_CONSTANTS, PERFORMANCE_CONSTANTS, getLocalizedFileFilter, generateUniqueId } from "../constants/constants";
 import { t } from "./LocalizationService";
 import { WebViewEditorService } from "./WebViewEditorService";
 
@@ -108,35 +108,40 @@ export class UIService implements IUIService {
               quickPick.hide();
 
               setTimeout(async () => {
-                const action = await this.showPromptActionMenu(selected.promptItem);
+                try {
+                  const action = await this.showPromptActionMenu(selected.promptItem);
 
-                if (action) {
-                  // 导入PromptManager来处理操作
-                  const { PromptManager } = await import("../models/PromptManager");
-                  const promptManager = PromptManager.getInstance();
+                  if (action) {
+                    // 导入PromptManager来处理操作
+                    const { PromptManager } = await import("../models/PromptManager");
+                    const promptManager = PromptManager.getInstance();
 
-                  switch (action) {
-                    case "edit":
-                      const edited = await this.showPromptEditor(selected.promptItem);
-                      if (edited) {
-                        await promptManager.updatePrompt(edited);
-                        await this.showInfo(t("message.saveSuccess"));
-                      }
-                      resolve(edited);
-                      break;
+                    switch (action) {
+                      case "edit":
+                        const edited = await this.showPromptEditor(selected.promptItem);
+                        if (edited) {
+                          await promptManager.updatePrompt(edited);
+                          await this.showInfo(t("message.saveSuccess"));
+                        }
+                        resolve(edited);
+                        break;
 
-                    case "delete":
-                      const confirmed = await this.showConfirmDialog(t("confirm.deletePrompt"));
-                      if (confirmed) {
-                        await promptManager.deletePrompt(selected.promptItem.id);
-                        await this.showInfo(t("message.deleteSuccess"));
-                      }
-                      resolve(undefined);
-                      break;
-                    default:
-                      resolve(undefined);
+                      case "delete":
+                        const confirmed = await this.showConfirmDialog(t("confirm.deletePrompt"));
+                        if (confirmed) {
+                          await promptManager.deletePrompt(selected.promptItem.id);
+                          await this.showInfo(t("message.deleteSuccess"));
+                        }
+                        resolve(undefined);
+                        break;
+                      default:
+                        resolve(undefined);
+                    }
+                  } else {
+                    resolve(undefined);
                   }
-                } else {
+                } catch (error) {
+                  console.error("操作菜单处理失败:", error);
                   resolve(undefined);
                 }
               }, 100);
@@ -166,10 +171,11 @@ export class UIService implements IUIService {
    */
   async showPromptEditor(
     prompt?: PromptItem,
-    context?: vscode.ExtensionContext
+    context?: vscode.ExtensionContext,
+    defaultCategoryId?: string
   ): Promise<PromptItem | undefined> {
     try {
-      return await this.showWebViewEditor(prompt, context);
+      return await this.showWebViewEditor(prompt, context, defaultCategoryId);
     } catch (error) {
       console.error("显示Prompt编辑器失败:", error);
       await this.showError("显示编辑界面失败");
@@ -183,10 +189,10 @@ export class UIService implements IUIService {
    * @param context 扩展上下文
    * @returns 编辑后的Prompt，如果取消则返回undefined
    */
-  async showWebViewEditor(prompt?: PromptItem, context?: vscode.ExtensionContext): Promise<PromptItem | undefined> {
+  async showWebViewEditor(prompt?: PromptItem, context?: vscode.ExtensionContext, defaultCategoryId?: string): Promise<PromptItem | undefined> {
     try {
       const webViewEditorService = WebViewEditorService.getInstance();
-      return await webViewEditorService.showEditor(prompt, context);
+      return await webViewEditorService.showEditor(prompt, context, defaultCategoryId);
     } catch (error) {
       console.error("显示WebView编辑器失败:", error);
       await this.showError("WebView编辑器启动失败");
@@ -569,6 +575,6 @@ export class UIService implements IUIService {
    * 生成唯一ID
    */
   private generateId(): string {
-    return "prompt_" + Date.now().toString(36) + Math.random().toString(36).substr(2);
+    return generateUniqueId('pm');
   }
 }

--- a/src/services/WebViewEditorService.ts
+++ b/src/services/WebViewEditorService.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { PromptItem, PromptCategory } from "../types";
+import { generateUniqueId } from "../constants/constants";
 
 export class WebViewEditorService {
   private static instance: WebViewEditorService;
@@ -24,7 +25,8 @@ export class WebViewEditorService {
    */
   async showEditor(
     prompt?: PromptItem,
-    context?: vscode.ExtensionContext
+    context?: vscode.ExtensionContext,
+    defaultCategoryId?: string
   ): Promise<PromptItem | undefined> {
     return new Promise((resolve) => {
       // 如果已经有面板开启，先关闭它
@@ -47,11 +49,11 @@ export class WebViewEditorService {
       this.panel.webview.html = this.getWebViewContent(prompt);
 
       // 处理来自 WebView 的消息
-      this.panel.webview.onDidReceiveMessage(
+      const messageDisposable = this.panel.webview.onDidReceiveMessage(
         async (message) => {
           switch (message.type) {
             case "ready":
-              await this.sendInitialData(prompt);
+              await this.sendInitialData(prompt, defaultCategoryId);
               break;
             case "save":
               const savedPrompt = await this.handleSave(message.data);
@@ -71,28 +73,30 @@ export class WebViewEditorService {
               await this.handleCreateCategory(message.data);
               break;
           }
-        },
-        undefined,
-        context?.subscriptions
+        }
       );
 
       // 监听面板关闭事件
       this.panel.onDidDispose(() => {
+        messageDisposable.dispose();
         this.panel = undefined;
         resolve(undefined);
       });
     });
   }
 
-  private async sendInitialData(prompt?: PromptItem): Promise<void> {
+  private async sendInitialData(prompt?: PromptItem, defaultCategoryId?: string): Promise<void> {
     if (!this.panel) return;
 
     const categories = await this.getCategories();
-    
+
+    // 如果没有 prompt 但有 defaultCategoryId，创建一个带默认分类的初始数据
+    const initPrompt = prompt || (defaultCategoryId ? { categoryId: defaultCategoryId } : null);
+
     this.panel.webview.postMessage({
       type: "init",
       data: {
-        prompt: prompt || null,
+        prompt: initPrompt,
         categories: categories,
       },
     });
@@ -723,10 +727,19 @@ export class WebViewEditorService {
         }
 
         function handleCategoryCreated(category) {
-            showSuccess('分类 "' + category.name + '" 创建成功');
-            
+            // 确保 option 存在后再选中
             const categorySelect = document.getElementById('category');
+            if (!Array.from(categorySelect.options).some(opt => opt.value === category.id)) {
+                const option = document.createElement('option');
+                option.value = category.id;
+                option.textContent = category.name;
+                categorySelect.appendChild(option);
+            }
+            if (!categories.some(c => c.id === category.id)) {
+                categories.push(category);
+            }
             categorySelect.value = category.id;
+            showSuccess('分类 "' + category.name + '" 创建成功');
         }
 
         function showError(message) {
@@ -755,7 +768,7 @@ export class WebViewEditorService {
   }
 
   private generateId(): string {
-    return Date.now().toString(36) + Math.random().toString(36).substr(2);
+    return generateUniqueId('pm');
   }
 
   dispose(): void {

--- a/src/views/PromptTreeDataProvider.ts
+++ b/src/views/PromptTreeDataProvider.ts
@@ -105,14 +105,15 @@ export class PromptTreeDataProvider implements IPromptTreeDataProvider {
    * @param filter 搜索关键词，null表示清除搜索
    */
   setSearchFilter(filter: string | null): void {
+    this.searchFilter = filter; // 立即更新值，确保 getSearchFilter() 返回最新值
+
     // 清除之前的防抖定时器
     if (this.searchTimeout) {
       clearTimeout(this.searchTimeout);
     }
 
-    // 设置新的防抖定时器
+    // 仅对 refresh 进行防抖
     this.searchTimeout = setTimeout(() => {
-      this.searchFilter = filter;
       this.refresh();
     }, 300); // 300ms防抖延迟
   }


### PR DESCRIPTION
## Summary

通过代码分析发现并修复了 10 个潜在 bug，涵盖运行时崩溃、功能缺陷、内存泄漏和代码冗余等问题。

### 高优先级修复
- **topCategories 显示 ID 而非名称** — 统计页面现在正确显示分类名称
- **添加到分类未传 categoryId** — 右键分类添加 Prompt 时自动预选该分类
- **createdAt 空值崩溃** — 可选链防止 TypeError

### 中优先级修复
- **WebView 新分类未自动选中** — 创建分类后确保 option 存在再设值
- **deleteCategory 双重清除** — 移除冗余逻辑，由 StorageService 统一处理
- **QuickPick Promise 悬挂** — try-catch 兜底确保 resolve 一定被调用
- **disposable 未管理** — 面板关闭时正确销毁消息监听器

### 低优先级修复
- **默认数据双重初始化** — StorageService 不再重复创建默认数据
- **搜索防抖返回旧值** — searchFilter 立即更新，仅防抖 refresh
- **generateId 统一化** — 新增 generateUniqueId() 集中管理 ID 生成

## Test plan
- [ ] 编译通过 (`npm run compile` ✅ 已验证)
- [ ] 统计页面显示分类名称而非 ID
- [ ] 右键分类 → 添加 Prompt → 分类下拉框自动选中
- [ ] 无 createdAt 的分类不会崩溃
- [ ] WebView 中创建新分类后自动选中
- [ ] 删除分类后子 Prompt 变为未分类
- [ ] 反复打开/关闭 WebView 编辑器无内存泄漏

https://claude.ai/code/session_01CMzLvzyY4jfoPxzLniJAvZ